### PR TITLE
fix: allow for dynamic subclassing in add_axioms()

### DIFF
--- a/src/ontor/ontor.py
+++ b/src/ontor/ontor.py
@@ -417,7 +417,7 @@ class OntoEditor:
                     if not any(axiom[i] for i in [1, 2, 4, 5, 6]) and not axiom[5] == 0:
                         continue
                     if (
-                        all(axiom[i] for i in [0, 1, -1])
+                        all(axiom[i] is not None for i in [0, 1, -1])
                         or all(axiom[i] for i in [2, 4, 6])
                         or all(axiom[i] for i in [2, 4, 7])
                     ):


### PR DESCRIPTION
It seems reasonable to me to check against `None` instead of `True` to not exclude dynamic subclassing, i.e., cases where `axiom[-1] == False`. As I understand it, line 427 can currently not be reached.