### PR TITLE
fix: include elem_type in creation of notion with parent

### DIFF
--- a/src/ontor/ontor.py
+++ b/src/ontor/ontor.py
@@ -314,7 +314,7 @@ class OntoEditor:
             if name and not parent:
                 notion = types.new_class(name, (type_dict[elem_type],))
             elif name and parent:
-                notion = types.new_class(name, (self.onto[parent],))
+                notion = types.new_class(name, (self.onto[parent], type_dict[elem_type],))
             else:
                 self.logger.warning(f"unexpected info: {name, parent, elem_type}")
                 raise InfoException

--- a/src/ontor/ontor.py
+++ b/src/ontor/ontor.py
@@ -313,8 +313,10 @@ class OntoEditor:
         with self.onto:
             if name and not parent:
                 notion = types.new_class(name, (type_dict[elem_type],))
-            elif name and parent:
+            elif name and parent and elem_type != "c":
                 notion = types.new_class(name, (self.onto[parent], type_dict[elem_type],))
+            elif name and parent and elem_type == "c":
+                notion = types.new_class(name, (self.onto[parent],))
             else:
                 self.logger.warning(f"unexpected info: {name, parent, elem_type}")
                 raise InfoException


### PR DESCRIPTION
It seems reasonable to also include the `elem_type` in the creation of new notions with parents.

I came across this when using `add_instances()`, as the use of a DataProperty created as a child of another DataProperty leads to erroneous behavior. Line 700 (`if DataProperty in pred.is_a:`) checks against the `elem_type`, which is currently only included for notions without parents. This seems to also apply to line 710. Predicates, that are created as children of other predicates, simply lack the `DataProperty` or `ObjectProperty` parent, which is required to evaluate the conditions (l.700, l.710) to true.

Here is a minimal example:
```
base_classes = [["foo", None],]
base_dps = [["has_value", None, True, None, None, None, None, None, None, None],
            ["has_string_value", "has_value", True, None, None, None, None, None, None, None],]
base_instances = [["bar", "foo", "has_string_value", "baz", "string"],]
```

Adding the instance currently results in pred.is_a `[base.has_value, owl.FunctionalProperty]` instead of the required `[base.has_value, owl.DatatypeProperty, owl.FunctionalProperty]`.
